### PR TITLE
Fix matplotlib.mlab.griddata deprecation

### DIFF
--- a/pandastable/plotting.py
+++ b/pandastable/plotting.py
@@ -38,7 +38,7 @@ import matplotlib as mpl
 #mpl.use("TkAgg")
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
-from matplotlib.mlab import griddata
+from scipy.interpolate import griddata
 from matplotlib.lines import Line2D
 import matplotlib.transforms as mtrans
 from collections import OrderedDict


### PR DESCRIPTION
matplotlib.mlab.griddata had be removed since matplotlib 3.1.0. Recommendation is to use scipy.interpolate.griddata instead.
https://matplotlib.org/3.1.0/api/api_changes.html?highlight=griddata